### PR TITLE
Revert "Feat/add gh actions to verify examples"

### DIFF
--- a/examples/call-contract/index.js
+++ b/examples/call-contract/index.js
@@ -14,15 +14,20 @@ const ExecutableSample = require('../../artifacts/examples/call-contract/Executa
 
 async function deploy(chain, wallet) {
     console.log(`Deploying ExecutableSample for ${chain.name}.`);
-    const provider = getDefaultProvider(chain.rpc);
-    chain.wallet = wallet.connect(provider);
-    chain.contract = await deployContract(wallet, ExecutableSample, [chain.gateway, chain.gasReceiver]);
-    console.log(`Deployed ExecutableSample for ${chain.name} at ${chain.contract.address}.`);
+    const contract = await deployContract(wallet, ExecutableSample, [chain.gateway, chain.gasReceiver]);
+    chain.executableSample = contract.address;
+    console.log(`Deployed ExecutableSample for ${chain.name} at ${chain.executableSample}.`);
 }
 
 async function test(chains, wallet, options) {
     const args = options.args || [];
     const getGasPrice = options.getGasPrice;
+
+    for (const chain of chains) {
+        const provider = getDefaultProvider(chain.rpc);
+        chain.wallet = wallet.connect(provider);
+        chain.contract = new Contract(chain.executableSample, ExecutableSample.abi, chain.wallet);
+    }
 
     const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
     const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
@@ -35,17 +40,17 @@ async function test(chains, wallet, options) {
     console.log('--- Initially ---');
     await logValue();
 
-    // Set the gasLimit to 3e5 (a safe overestimate) and get the gas price.
+    //Set the gasLimit to 3e5 (a safe overestimate) and get the gas price.
     const gasLimit = 3e5;
     const gasPrice = await getGasPrice(source, destination, AddressZero);
 
-    const tx = await source.contract.setRemoteValue(destination.name, destination.contract.address, message, {
+    const tx = await source.contract.setRemoteValue(destination.name, destination.executableSample, message, {
         value: BigInt(Math.floor(gasLimit * gasPrice)),
     });
     await tx.wait();
 
     while ((await destination.contract.value()) !== message) {
-        await sleep(1000);
+        await sleep(2000);
     }
 
     console.log('--- After ---');

--- a/examples/deposit-address/index.js
+++ b/examples/deposit-address/index.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const { getDefaultProvider, Contract } = require('ethers');
+const {
+    getDefaultProvider,
+    Contract,
+    constants: { AddressZero },
+} = require('ethers');
 
 const Gateway = require('../../artifacts/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol/IAxelarGateway.json');
 const IERC20 = require('../../artifacts/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IERC20.sol/IERC20.json');
@@ -26,7 +30,6 @@ async function test(chains, wallet, options = {}) {
         console.log(`Balance at ${source.name} is ${await source.token.balanceOf(wallet.address)}`);
         console.log(`Balance at ${destination.name} is ${await destination.token.balanceOf(destinationAddress)}`);
     }
-
     function sleep(ms) {
         return new Promise((resolve) => {
             setTimeout(() => {
@@ -34,18 +37,18 @@ async function test(chains, wallet, options = {}) {
             }, ms);
         });
     }
-
     const balance = await destination.token.balanceOf(destinationAddress);
     console.log('--- Initially ---');
     await print();
 
     const depositAddress = await getDepositAddress(source.name, destination.name, destinationAddress, symbol);
+    console.log(depositAddress);
     await (await source.token.transfer(depositAddress, amount)).wait();
 
     while (true) {
         const newBalance = await destination.token.balanceOf(destinationAddress);
         if (Number(balance) !== Number(newBalance)) break;
-        await sleep(1000);
+        await sleep(2000);
     }
 
     console.log('--- After ---');

--- a/examples/forecall/forecallService.js
+++ b/examples/forecall/forecallService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('dotenv').config();
+require("dotenv").config();
 const {
     getDefaultProvider,
     Contract,
@@ -26,7 +26,6 @@ async function getChains(env) {
     if (env == null || (env !== 'testnet' && env !== 'local'))
         throw new Error('Need to specify tesntet or local as an argument to this script.');
     let temp;
-
     if (env == 'local') {
         temp = require(`../info/local.json`);
     } else {
@@ -36,7 +35,6 @@ async function getChains(env) {
             temp = testnetInfo;
         }
     }
-
     const chains = temp;
 
     for (const chain of [source, destination]) {
@@ -48,7 +46,6 @@ async function getChains(env) {
         chain.usdc = new Contract(usdcAddress, IERC20.abi, chain.wallet);
         chain.lastBlock = await chain.provider.getBlockNumber();
     }
-
     return chains;
 }
 
@@ -56,7 +53,6 @@ async function fundForecaller(chains, forecaller, amount) {
     const private_key_funded = process.env.EVM_PRIVATE_KEY;
     const wallet_funded = new Wallet(private_key_funded);
     console.log(`Trying to give ${amount / 1e6} aUSDC to forecaller ${forecaller} from ${wallet_funded.address}.`);
-
     for (const chain of chains) {
         const balance_funded = await chain.usdc.balanceOf(wallet_funded.address);
         const balance_forecaller = await chain.usdc.balanceOf(forecaller);
@@ -74,7 +70,6 @@ async function update(chains) {
         const filter = chain.gateway.CallContractWithToken(chain.contract.address);
         const outgoing = await chain.gateway.queryFilter(filter, chain.lastBlock, N - 1);
         chain.lastBlock = N;
-
         for (const event of outgoing) {
             console.log(`${chain.name}, ${event.args.payload}.`);
         }

--- a/examples/forecall/index.js
+++ b/examples/forecall/index.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const { Contract, getDefaultProvider } = require('ethers');
+const {
+    getDefaultProvider,
+    Contract,
+    constants: { AddressZero },
+} = require('ethers');
 const { deployUpgradable } = require('@axelar-network/axelar-gmp-sdk-solidity');
 
 const ExampleProxy = require('../../artifacts/examples/Proxy.sol/ExampleProxy.json');
@@ -12,11 +16,9 @@ const { defaultAbiCoder, keccak256 } = require('ethers/lib/utils');
 
 async function deploy(chain, wallet) {
     console.log(`Deploying DistributionForecallable for ${chain.name}.`);
-    const provider = getDefaultProvider(chain.rpc);
-    chain.wallet = wallet.connect(provider);
-    chain.contract = await deployUpgradable(
+    const contract = await deployUpgradable(
         chain.constAddressDeployer,
-        chain.wallet,
+        wallet,
         DistributionForecallable,
         ExampleProxy,
         [chain.gateway, chain.gasReceiver],
@@ -24,10 +26,8 @@ async function deploy(chain, wallet) {
         '0x',
         'forecallable',
     );
-    chain.gateway = new Contract(chain.gateway, Gateway.abi, chain.wallet);
-    const usdcAddress = chain.gateway.tokenAddresses('aUSDC');
-    chain.usdc = new Contract(usdcAddress, IERC20.abi, chain.wallet);
-    console.log(`Deployed DistributionForecallable for ${chain.name} at ${chain.contract.address}.`);
+    chain.distributionForecallable = contract.address;
+    console.log(`Deployed DistributionForecallable for ${chain.name} at ${chain.distributionForecallable}.`);
 }
 
 async function test(chains, wallet, options) {
@@ -37,15 +37,30 @@ async function test(chains, wallet, options) {
     const amount = Math.floor(parseFloat(args[2])) * 1e6 || 10e6;
     const accounts = args.slice(3);
     if (accounts.length === 0) accounts.push('0xe7490F73133dfE46D9734B1963EBe00Cb656Ed47');
+    for (const chain of [source, destination]) {
+        const provider = getDefaultProvider(chain.rpc);
+        chain.wallet = wallet.connect(provider);
+        chain.contract = await deployUpgradable(
+            chain.constAddressDeployer,
+            chain.wallet,
+            DistributionForecallable,
+            ExampleProxy,
+            [chain.gateway, chain.gasReceiver],
+            [],
+            '0x',
+            'forecallable',
+        );
+        chain.gateway = new Contract(chain.gateway, Gateway.abi, chain.wallet);
+        const usdcAddress = chain.gateway.tokenAddresses('aUSDC');
+        chain.usdc = new Contract(usdcAddress, IERC20.abi, chain.wallet);
+    }
 
     async function print() {
         console.log(`Forecaller ${wallet.address} has ${(await destination.usdc.balanceOf(wallet.address)) / 1e6} aUSDC`);
-
         for (const account of accounts) {
             console.log(`${account} has ${(await destination.usdc.balanceOf(account)) / 1e6} aUSDC`);
         }
     }
-
     function sleep(ms) {
         return new Promise((resolve) => {
             setTimeout(() => {
@@ -69,7 +84,12 @@ async function test(chains, wallet, options) {
 
     const forecallAmount = await destination.contract.amountPostFee(amount - axelarFee, payload);
     await (await destination.usdc.approve(destination.contract.address, forecallAmount)).wait();
-    await (await destination.contract.forecallWithToken(source.name, source.contract.address, payload, 'aUSDC', amount - axelarFee)).wait();
+    await (
+        await destination.contract.forecallWithToken(source.name, source.distributionForecallable, payload, 'aUSDC', amount - axelarFee)
+    ).wait();
+
+    console.log('--- After forecall but before execution ---');
+    await print();
 
     const filter = destination.gateway.filters.ContractCallApprovedWithMint(
         null,
@@ -79,13 +99,21 @@ async function test(chains, wallet, options) {
         keccak256(payload),
     );
     let validated;
-
     while (true) {
         validated = (await destination.gateway.queryFilter(filter))[0];
         if (validated) break;
         await sleep(1000);
     }
-
+    const tx = await (
+        await destination.contract.executeWithToken(
+            validated.args.commandId,
+            source.name,
+            source.distributionForecallable,
+            payload,
+            'aUSDC',
+            amount - axelarFee,
+        )
+    ).wait();
     console.log('--- After a execution ---');
     await print();
 }

--- a/examples/headers/index.js
+++ b/examples/headers/index.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const { getDefaultProvider, Contract } = require('ethers');
+const {
+    getDefaultProvider,
+    Contract,
+    constants: { AddressZero },
+} = require('ethers');
 const { deployUpgradable } = require('@axelar-network/axelar-gmp-sdk-solidity');
 
 const ExampleProxy = require('../../artifacts/examples/Proxy.sol/ExampleProxy.json');
@@ -10,11 +14,9 @@ const IERC20 = require('../../artifacts/@axelar-network/axelar-gmp-sdk-solidity/
 
 async function deploy(chain, wallet) {
     console.log(`Deploying Headers for ${chain.name}.`);
-    chain.provider = getDefaultProvider(chain.rpc);
-    chain.wallet = wallet.connect(chain.provider);
-    chain.contract = await deployUpgradable(
+    const contract = await deployUpgradable(
         chain.constAddressDeployer,
-        chain.wallet,
+        wallet,
         Headers,
         ExampleProxy,
         [chain.gateway, chain.gasReceiver, 10],
@@ -22,16 +24,30 @@ async function deploy(chain, wallet) {
         '0x',
         'headers',
     );
-    const gateway = new Contract(chain.gateway, Gateway.abi, chain.wallet);
-    const usdcAddress = await gateway.tokenAddresses('aUSDC');
-    chain.usdc = new Contract(usdcAddress, IERC20.abi, chain.wallet);
-    console.log(`Deployed Headers for ${chain.name} at ${chain.contract.address}.`);
+    chain.headers = contract.address;
+    console.log(`Deployed Headers for ${chain.name} at ${chain.headers}.`);
 }
 
 async function test(chains, wallet, options) {
     const args = options.args || [];
     const getGasPrice = options.getGasPrice;
-
+    for (const chain of chains) {
+        chain.provider = getDefaultProvider(chain.rpc);
+        chain.wallet = wallet.connect(chain.provider);
+        chain.contract = await deployUpgradable(
+            chain.constAddressDeployer,
+            chain.wallet,
+            Headers,
+            ExampleProxy,
+            [chain.gateway, chain.gasReceiver, 10],
+            [],
+            '0x',
+            'headers',
+        );
+        const gateway = new Contract(chain.gateway, Gateway.abi, chain.wallet);
+        const usdcAddress = await gateway.tokenAddresses('aUSDC');
+        chain.usdc = new Contract(usdcAddress, IERC20.abi, chain.wallet);
+    }
     const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
     const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
 
@@ -54,9 +70,13 @@ async function test(chains, wallet, options) {
     const hash = (await source.provider.getBlock(tx.blockNumber - 1)).hash;
 
     while (true) {
-        const remoteHash = await destination.contract.getHeader(source.name, 0).catch(() => ({}));
-        if (remoteHash.header_ === hash && tx.blockNumber - 1 === remoteHash.block_.toNumber()) break;
-        await sleep(1000);
+        try {
+            const remoteHash = await destination.contract.getHeader(source.name, 0);
+            if (remoteHash.header_ == hash && tx.blockNumber - 1 == remoteHash.block_) break;
+            await sleep(2000);
+        } catch (e) {
+            await sleep(2000);
+        }
     }
 
     console.log('Success!');

--- a/examples/nft-auctionhouse/auction.js
+++ b/examples/nft-auctionhouse/auction.js
@@ -14,27 +14,26 @@ const {
 const ERC721 = require('../../artifacts/examples/nft-auctionhouse/ERC721Demo.sol/ERC721Demo.json');
 const NftAuctionhouse = require('../../artifacts/examples/nft-auctionhouse/NftAuctionhouseRemote.sol/NftAuctionhouseRemote.json');
 
-async function auction(chain, privateKey, tokenId, deadline, min) {
+async function auction(chain, private_key, tokenId, deadline, min) {
     deadline = deadline || Math.floor(new Date().getTime() / 1000 + 60);
     min = min || 0;
     const provider = getDefaultProvider(chain.rpc);
-    const wallet = new Wallet(privateKey, provider);
+    const wallet = new Wallet(private_key, provider);
     const erc721 = new Contract(chain.erc721, ERC721.abi, wallet);
-    const auctionhouse = new Contract(chain.contract.address, NftAuctionhouse.abi, wallet);
+    const auctionhouse = new Contract(chain.nftAuctionhouse, NftAuctionhouse.abi, wallet);
 
-    await (await erc721.approve(auctionhouse.address, tokenId)).wait();
+    await await erc721.approve(auctionhouse.address, tokenId);
 
-    await (await auctionhouse.auction(erc721.address, tokenId, min, deadline)).wait();
+    await await auctionhouse.auction(erc721.address, tokenId, min, deadline);
 }
 
 module.exports = auction;
 
 if (require.main === module) {
     const env = process.argv[2];
-    if (env == null || (env !== 'testnet' && env !== 'local'))
+    if (env == null || (env != 'testnet' && env != 'local'))
         throw new Error('Need to specify tesntet or local as an argument to this script.');
     let temp;
-
     if (env == 'local') {
         temp = require(`../../info/local.json`);
     } else {
@@ -44,17 +43,16 @@ if (require.main === module) {
             temp = testnetInfo;
         }
     }
-
     const chains = temp;
     const args = process.argv.slice(3);
 
     const chainName = args[0];
-    const privateKey = args[1];
+    const private_key = args[1];
     const tokenId = BigInt(args[2]);
 
     const chain = chains.find((chain) => chain.name == chainName);
     const deadline = BigInt(args[3] || Math.floor(new Date().getTime() / 1000 + 60));
     const min = BigInt(args[4] || 0);
 
-    auction(chain, privateKey, tokenId, deadline, min);
+    auction(chain, private_key, tokenId, deadline, min);
 }

--- a/examples/nft-auctionhouse/bid.js
+++ b/examples/nft-auctionhouse/bid.js
@@ -7,31 +7,31 @@ const {
     utils: { keccak256, defaultAbiCoder },
     Wallet,
 } = require('ethers');
+const {
+    utils: { deployContract },
+} = require('@axelar-network/axelar-local-dev');
 
 const ERC721 = require('../../artifacts/examples/nft-auctionhouse/ERC721Demo.sol/ERC721Demo.json');
 const NftAuctionhouse = require('../../artifacts/examples/nft-auctionhouse/NftAuctionhouseRemote.sol/NftAuctionhouseRemote.json');
 const IAxelarGateway = require('../../artifacts/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol/IAxelarGateway.json');
 const IERC20 = require('../../artifacts/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IERC20.sol/IERC20.json');
 
-async function bid(chain, privateKey, tokenId, amount) {
+async function bid(chain, private_key, tokenId, amount) {
     const provider = getDefaultProvider(chain.rpc);
-    const wallet = new Wallet(privateKey, provider);
+    const wallet = new Wallet(private_key, provider);
     const erc721 = new Contract(chain.erc721, ERC721.abi, wallet);
     const gateway = new Contract(chain.gateway, IAxelarGateway.abi, wallet);
     const usdc = new Contract(await gateway.tokenAddresses('aUSDC'), IERC20.abi, wallet);
-    const auctionhouse = new Contract(chain.contract.address, NftAuctionhouse.abi, wallet);
-
-    if (amount === 0) {
+    const auctionhouse = new Contract(chain.nftAuctionhouse, NftAuctionhouse.abi, wallet);
+    if (amount == 0) {
         const bid = await auctionhouse.bids(erc721.address, tokenId);
         const minAmount = await auctionhouse.minAmounts(erc721.address, tokenId);
-
-        if (bid === 0) {
-            amount = minAmount === BigInt(await auctionhouse.NO_MIN()) ? 100 : minAmount;
+        if (bid == 0) {
+            amount = minAmount == BigInt(await auctionhouse.NO_MIN()) ? 100 : minAmount;
         } else {
             amount = Math.floor((bid * 4) / 3 + 1);
         }
     }
-
     await await usdc.approve(auctionhouse.address, amount);
     await await auctionhouse.bid(erc721.address, tokenId, amount);
 }
@@ -43,7 +43,6 @@ if (require.main === module) {
     if (env == null || (env != 'testnet' && env != 'local'))
         throw new Error('Need to specify tesntet or local as an argument to this script.');
     let temp;
-
     if (env == 'local') {
         temp = require(`../../info/local.json`);
     } else {
@@ -53,7 +52,6 @@ if (require.main === module) {
             temp = testnetInfo;
         }
     }
-
     const chains = temp;
     const args = process.argv.slice(3);
 

--- a/examples/nft-auctionhouse/bidRemote.js
+++ b/examples/nft-auctionhouse/bidRemote.js
@@ -4,35 +4,36 @@ const {
     getDefaultProvider,
     Contract,
     constants: { AddressZero },
+    utils: { keccak256, defaultAbiCoder },
     Wallet,
 } = require('ethers');
-const {} = require('@axelar-network/axelar-local-dev');
+const {
+    utils: { deployContract },
+} = require('@axelar-network/axelar-local-dev');
 
 const NftAuctionhouse = require('../../artifacts/examples/nft-auctionhouse/NftAuctionhouseRemote.sol/NftAuctionhouseRemote.json');
 const IAxelarGateway = require('../../artifacts/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol/IAxelarGateway.json');
 const IERC20 = require('../../artifacts/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IERC20.sol/IERC20.json');
 
-async function bidRemote(sourceChain, destinationChain, privateKey, tokenId, amount, options = null) {
+async function bidRemote(sourceChain, destinationChain, private_key, tokenId, amount, options = null) {
     const provider = getDefaultProvider(sourceChain.rpc);
-    const wallet = new Wallet(privateKey, provider);
+    const wallet = new Wallet(private_key, provider);
     const gateway = new Contract(sourceChain.gateway, IAxelarGateway.abi, wallet);
     const usdc = new Contract(await gateway.tokenAddresses('aUSDC'), IERC20.abi, wallet);
-    const auctionhouse = new Contract(sourceChain.contract.address, NftAuctionhouse.abi, wallet);
+    const auctionhouse = new Contract(sourceChain.nftAuctionhouse, NftAuctionhouse.abi, wallet);
 
     const destinationProvider = getDefaultProvider(destinationChain.rpc);
-    const destinationAuctionhouse = new Contract(destinationChain.contract.address, NftAuctionhouse.abi, destinationProvider);
+    const destinationAuctionhouse = new Contract(destinationChain.nftAuctionhouse, NftAuctionhouse.abi, destinationProvider);
     const lastBid = await destinationAuctionhouse.bids(destinationChain.erc721, tokenId);
 
-    if (amount === 0) {
+    if (amount == 0) {
         const minAmount = await destinationAuctionhouse.minAmounts(destinationChain.erc721, tokenId);
-
-        if (lastBid === 0) {
-            amount = BigInt(minAmount) === BigInt(await destinationAuctionhouse.NO_MIN()) ? 3e6 : minAmount;
+        if (lastBid == 0) {
+            amount = BigInt(minAmount) == BigInt(await destinationAuctionhouse.NO_MIN()) ? 3e6 : minAmount;
         } else {
             amount = Math.floor((lastBid * 4) / 3 + 1);
         }
     }
-
     const gasLimit = 3e5;
     const gasPrice = (await options?.getGasPrice(sourceChain, destinationChain, AddressZero)) || 1;
 
@@ -41,7 +42,7 @@ async function bidRemote(sourceChain, destinationChain, privateKey, tokenId, amo
     await (
         await auctionhouse.bidRemote(
             destinationChain.name,
-            destinationChain.contract.address,
+            destinationChain.nftAuctionhouse,
             destinationChain.erc721,
             tokenId,
             wallet.address,
@@ -57,10 +58,9 @@ async function bidRemote(sourceChain, destinationChain, privateKey, tokenId, amo
             }, ms);
         });
     }
-
     while (true) {
         const currentBid = await destinationAuctionhouse.bids(destinationChain.erc721, tokenId);
-        // console.log(`Waiting for bid... Last bid: ${lastBid}, currentBid: ${currentBid}.`);
+        //console.log(`Waiting for bid... Last bid: ${lastBid}, currentBid: ${currentBid}.`);
         if (currentBid * 3 > lastBid * 4) break;
         await sleep(1000);
     }
@@ -73,7 +73,6 @@ if (require.main === module) {
     if (env == null || (env != 'testnet' && env != 'local'))
         throw new Error('Need to specify tesntet or local as an argument to this script.');
     let temp;
-
     if (env == 'local') {
         temp = require(`../../info/local.json`);
     } else {
@@ -83,7 +82,6 @@ if (require.main === module) {
             temp = testnetInfo;
         }
     }
-
     const chains = temp;
     const args = process.argv.slice(3);
 

--- a/examples/nft-auctionhouse/resolveAuction.js
+++ b/examples/nft-auctionhouse/resolveAuction.js
@@ -1,15 +1,26 @@
 'use strict';
 
-const { getDefaultProvider, Contract, Wallet } = require('ethers');
+const {
+    getDefaultProvider,
+    Contract,
+    constants: { AddressZero },
+    utils: { keccak256, defaultAbiCoder },
+    Wallet,
+} = require('ethers');
+const {
+    utils: { deployContract },
+} = require('@axelar-network/axelar-local-dev');
 
+const ERC721 = require('../../artifacts/examples/nft-auctionhouse/ERC721Demo.sol/ERC721Demo.json');
 const NftAuctionhouse = require('../../artifacts/examples/nft-auctionhouse/NftAuctionhouseRemote.sol/NftAuctionhouseRemote.json');
 
-async function resolveAuction(chain, privateKey, tokenId) {
+async function resolveAuction(chain, private_key, tokenId) {
     const provider = getDefaultProvider(chain.rpc);
-    const wallet = new Wallet(privateKey, provider);
-    const auctionhouse = new Contract(chain.contract.address, NftAuctionhouse.abi, wallet);
+    const wallet = new Wallet(private_key, provider);
+    const erc721 = new Contract(chain.erc721, ERC721.abi, wallet);
+    const auctionhouse = new Contract(chain.nftAuctionhouse, NftAuctionhouse.abi, wallet);
 
-    await (await auctionhouse.resolveAuction(chain.erc721, tokenId)).wait();
+    await await auctionhouse.resolveAuction(chain.erc721, tokenId);
 }
 
 module.exports = resolveAuction;
@@ -19,7 +30,6 @@ if (require.main === module) {
     if (env == null || (env != 'testnet' && env != 'local'))
         throw new Error('Need to specify tesntet or local as an argument to this script.');
     let temp;
-
     if (env == 'local') {
         temp = require(`../../info/local.json`);
     } else {
@@ -29,7 +39,6 @@ if (require.main === module) {
             temp = testnetInfo;
         }
     }
-
     const chains = temp;
     const args = process.argv.slice(3);
 

--- a/examples/nft-linker/index.js
+++ b/examples/nft-linker/index.js
@@ -19,12 +19,12 @@ const tokenId = 0;
 
 async function deploy(chain, wallet) {
     console.log(`Deploying ERC721Demo for ${chain.name}.`);
-    chain.erc721 = await deployContract(wallet, ERC721, ['Test', 'TEST']);
+    const erc721 = await deployContract(wallet, ERC721, ['Test', 'TEST']);
+    chain.erc721 = erc721.address;
     console.log(`Deployed ERC721Demo for ${chain.name} at ${chain.erc721}.`);
     console.log(`Deploying NftLinker for ${chain.name}.`);
     const provider = getDefaultProvider(chain.rpc);
-    chain.wallet = wallet.connect(provider);
-    chain.contract = await deployUpgradable(
+    const contract = await deployUpgradable(
         chain.constAddressDeployer,
         wallet.connect(provider),
         NftLinker,
@@ -34,40 +34,51 @@ async function deploy(chain, wallet) {
         defaultAbiCoder.encode(['string'], [chain.name]),
         'nftLinker',
     );
-    console.log(`Deployed NftLinker for ${chain.name} at ${chain.contract.address}.`);
+    chain.nftLinker = contract.address;
+    console.log(`Deployed NftLinker for ${chain.name} at ${chain.nftLinker}.`);
     console.log(`Minting token ${tokenId} for ${chain.name}`);
-    await (await chain.erc721.mint(tokenId)).wait();
+    await (await erc721.mint(tokenId)).wait();
     console.log(`Minted token ${tokenId} for ${chain.name}`);
 }
 
 async function test(chains, wallet, options) {
     const args = options.args || [];
     const getGasPrice = options.getGasPrice;
-
-    const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
-    const originChain = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
+    for (const chain of chains) {
+        const provider = getDefaultProvider(chain.rpc);
+        chain.wallet = wallet.connect(provider);
+        chain.contract = await deployUpgradable(
+            chain.constAddressDeployer,
+            chain.wallet,
+            NftLinker,
+            ExampleProxy,
+            [chain.gateway, chain.gasReceiver],
+            [],
+            defaultAbiCoder.encode(['string'], [chain.name]),
+            'nftLinker',
+        );
+        chain.erc721 = new Contract(chain.erc721, ERC721.abi, chain.wallet);
+    }
+    const destination = chains.find((chain) => chain.name == (args[1] || 'Fantom'));
+    const originChain = chains.find((chain) => chain.name == (args[0] || 'Avalanche'));
 
     const ownerOf = async (chain = originChain) => {
         const operator = chain.erc721;
         const owner = await operator.ownerOf(tokenId);
-
         if (owner !== chain.contract.address) {
             return { chain: chain.name, address: owner, tokenId: BigInt(tokenId) };
+        } else {
+            const newTokenId = BigInt(
+                keccak256(defaultAbiCoder.encode(['string', 'address', 'uint256'], [chain.name, operator.address, tokenId])),
+            );
+            for (let checkingChain of chains) {
+                if (checkingChain == chain) continue;
+                try {
+                    const address = await checkingChain.contract.ownerOf(newTokenId);
+                    return { chain: checkingChain.name, address: address, tokenId: newTokenId };
+                } catch (e) {}
+            }
         }
-
-        const newTokenId = BigInt(
-            keccak256(defaultAbiCoder.encode(['string', 'address', 'uint256'], [chain.name, operator.address, tokenId])),
-        );
-
-        for (const checkingChain of chains) {
-            if (checkingChain === chain) continue;
-
-            try {
-                const address = await checkingChain.contract.ownerOf(newTokenId);
-                return { chain: checkingChain.name, address, tokenId: newTokenId };
-            } catch (e) {}
-        }
-
         return { chain: '' };
     };
 
@@ -77,7 +88,6 @@ async function test(chains, wallet, options) {
             console.log(`Token that was originally minted at ${chain.name} is at ${owner.chain}.`);
         }
     }
-
     function sleep(ms) {
         return new Promise((resolve) => {
             setTimeout(() => {
@@ -99,7 +109,6 @@ async function test(chains, wallet, options) {
     if (originChain === source) {
         await (await source.erc721.approve(source.contract.address, owner.tokenId)).wait();
     }
-
     await (
         await source.contract.sendNFT(
             originChain === source ? source.erc721.address : source.contract.address,

--- a/examples/nonced-execution/index.js
+++ b/examples/nonced-execution/index.js
@@ -16,9 +16,6 @@ const time = new Date().getTime();
 
 async function deploy(chain, wallet) {
     console.log(`Deploying NoncedContractCallSender for ${chain.name}.`);
-    chain.provider = getDefaultProvider(chain.rpc);
-    chain.wallet = wallet.connect(chain.provider);
-
     const executableAddress = await predictContractConstant(
         chain.constAddressDeployer,
         wallet,
@@ -27,7 +24,7 @@ async function deploy(chain, wallet) {
         [],
     );
 
-    chain.sender = await deployAndInitContractConstant(
+    const sender = await deployAndInitContractConstant(
         chain.constAddressDeployer,
         wallet,
         CallSender,
@@ -35,44 +32,50 @@ async function deploy(chain, wallet) {
         [],
         [chain.gateway, chain.gasReceiver, executableAddress],
     );
-    console.log(`Deployed NoncedContractCallSender for ${chain.name} at ${chain.sender.address}.`);
+    chain.noncedSender = sender.address;
+    console.log(`Deployed NoncedContractCallSender for ${chain.name} at ${chain.noncedSender}.`);
 
     console.log(`Deploying ExecutableImplementation for ${chain.name}.`);
-    chain.contract = await deployUpgradable(
+    const executable = await deployUpgradable(
         chain.constAddressDeployer,
         wallet,
         Executable,
         ExampleProxy,
         [chain.gateway],
         [],
-        defaultAbiCoder.encode(['address'], [chain.sender.address]),
+        defaultAbiCoder.encode(['address'], [sender.address]),
         'call-executable-' + time,
     );
-    if (chain.contract.address.toLowerCase() !== executableAddress.toLowerCase())
-        throw new Error(`Not deployed as expected! ${chain.contract.address} was supposed to be ${executableAddress}`);
+    if (executable.address.toLowerCase() !== executableAddress.toLowerCase())
+        throw new Error(`Not deployed as expected! ${executable.address} was supposed to be ${executableAddress}`);
 
-    console.log(`Deployed ExecutableImplementation for ${chain.name} at ${chain.contract.address}.`);
+    chain.noncedExecutable = executable.address;
+    console.log(`Deployed ExecutableImplementation for ${chain.name} at ${chain.noncedExecutable}.`);
 }
 
 async function test(chains, wallet, options) {
     const args = options.args || [];
     const getGasPrice = options.getGasPrice;
-
+    for (const chain of chains) {
+        chain.provider = getDefaultProvider(chain.rpc);
+        chain.wallet = wallet.connect(chain.provider);
+        chain.sender = new Contract(chain.noncedSender, CallSender.abi, chain.wallet);
+        chain.executable = new Contract(chain.noncedExecutable, Executable.abi, chain.wallet);
+    }
     const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
     const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
     const message = args[2] || `Hello, the time is ${time}.`;
     const payload = defaultAbiCoder.encode(['string'], [message]);
-    const expectedNonce = await destination.contract.incomingNonces(source.name, wallet.address);
+    const expectedNonce = await destination.executable.incomingNonces(source.name, wallet.address);
 
     async function print() {
-        const nonce = await destination.contract.incomingNonces(source.name, wallet.address);
+        const nonce = await destination.executable.incomingNonces(source.name, wallet.address);
         console.log(
             `Last message sent from ${source.name} @ ${wallet.address} to ${destination.name} was "${
-                nonce >= 0 ? await destination.contract.messages(source.name, wallet.address, nonce) : ''
+                nonce >= 0 ? await destination.executable.messages(source.name, wallet.address, nonce) : ''
             }" with a nonce of ${nonce}.`,
         );
     }
-
     function sleep(ms) {
         return new Promise((resolve) => {
             setTimeout(() => {
@@ -80,7 +83,6 @@ async function test(chains, wallet, options) {
             }, ms);
         });
     }
-
     console.log('--- Initially ---');
     await print();
 
@@ -89,7 +91,7 @@ async function test(chains, wallet, options) {
 
     await (await source.sender.sendContractCall(destination.name, payload, { value: BigInt(Math.floor(gasLimit * gasPrice)) })).wait();
 
-    while ((await destination.contract.messages(source.name, wallet.address, expectedNonce)) !== message) {
+    while ((await destination.executable.messages(source.name, wallet.address, expectedNonce)) !== message) {
         await sleep(2000);
     }
 

--- a/examples/send-ack/index.js
+++ b/examples/send-ack/index.js
@@ -16,22 +16,26 @@ const SendAckSender = require('../../artifacts/examples/send-ack/SendAckSender.s
 const time = new Date().getTime();
 
 async function deploy(chain, wallet) {
-    chain.provider = getDefaultProvider(chain.rpc);
-    chain.wallet = wallet.connect(chain.provider);
-
     console.log(`Deploying SendAckSender for ${chain.name}.`);
-    chain.sender = await deployContract(wallet, SendAckSender, [chain.gateway, chain.gasReceiver, chain.name]);
-    console.log(`Deployed SendAckSender for ${chain.name} at ${chain.sender.address}.`);
+    const sender = await deployContract(wallet, SendAckSender, [chain.gateway, chain.gasReceiver, chain.name]);
+    chain.sendAckSender = sender.address;
+    console.log(`Deployed SendAckSender for ${chain.name} at ${chain.sendAckSender}.`);
 
     console.log(`Deploying SendAckReceiverImplementation for ${chain.name}.`);
-    chain.receiver = await deployContract(wallet, SendAckReceiver, [chain.gateway]);
-    console.log(`Deployed SendAckReceiverImplementation for ${chain.name} at ${chain.receiver.address}.`);
+    const receiver = await deployContract(wallet, SendAckReceiver, [chain.gateway]);
+    chain.sendAckReceiver = receiver.address;
+    console.log(`Deployed SendAckReceiverImplementation for ${chain.name} at ${chain.sendAckReceiver}.`);
 }
 
 async function test(chains, wallet, options) {
     const args = options.args || [];
     const getGasPrice = options.getGasPrice;
-
+    for (const chain of chains) {
+        chain.provider = getDefaultProvider(chain.rpc);
+        chain.wallet = wallet.connect(chain.provider);
+        chain.sender = new Contract(chain.sendAckSender, SendAckSender.abi, chain.wallet);
+        chain.receiver = new Contract(chain.sendAckReceiver, SendAckReceiver.abi, chain.wallet);
+    }
     const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
     const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
     const message = args[2] || `Hello, the time is ${time}.`;
@@ -45,7 +49,6 @@ async function test(chains, wallet, options) {
             }".`,
         );
     }
-
     function sleep(ms) {
         return new Promise((resolve) => {
             setTimeout(() => {
@@ -53,7 +56,6 @@ async function test(chains, wallet, options) {
             }, ms);
         });
     }
-
     console.log('--- Initially ---');
     await print();
 
@@ -69,12 +71,10 @@ async function test(chains, wallet, options) {
             value: gasAmountRemote + gasAmountSource,
         })
     ).wait();
-    const event = tx.events.find((event) => event.event === 'ContractCallSent');
+    const event = tx.events.find((event) => event.event == 'ContractCallSent');
     const nonce = event.args.nonce;
 
     while (!(await source.sender.executed(nonce))) {
-        console.log('MessageLength', await destination.receiver.messagesLength());
-        console.log('Test', await source.sender.executed(nonce));
         await sleep(2000);
     }
 

--- a/scripts/createLocal.js
+++ b/scripts/createLocal.js
@@ -1,42 +1,39 @@
-require('dotenv').config();
+require("dotenv").config();
 const { createAndExport, createAptosNetwork } = require('@axelar-network/axelar-local-dev');
-const { Wallet } = require('ethers');
+const { Wallet, utils: {keccak256, defaultAbiCoder} } = require('ethers');
 
-async function createLocal(toFund = []) {
+async function createLocal (toFund = []) {
     try {
         await createAptosNetwork();
         console.log('Initialized aptos.');
-    } catch {
+    } catch (e) {
         console.log('Could not initialize aptos, rerun this after starting an aptos node for proper support.');
     }
-
     async function callback(chain, info) {
         await chain.deployToken('Axelar Wrapped aUSDC', 'aUSDC', 6, BigInt(1e70));
-
-        for (const address of toFund) {
+        for(const address of toFund) {
             await chain.giveToken(address, 'aUSDC', BigInt(1e18));
         }
     }
 
     await createAndExport({
-        chainOutputPath: './info/local.json',
+        chainOutputPath: "./info/local.json",
         accountsToFund: toFund,
-        callback,
+        callback: callback,
     });
 }
 
 module.exports = {
     createLocal,
-};
+}
 
-if (require.main === module) {
+if (require.main === module) {    
     const deployer_key = process.env.EVM_PRIVATE_KEY;
     const deployer_address = new Wallet(deployer_key).address;
-    const toFund = [deployer_address];
+    const toFund = [deployer_address]
 
-    for (let j = 2; j < process.argv.length; j++) {
+    for(let j=2; j<process.argv.length; j++) {
         toFund.push(process.argv[j]);
     }
-
     createLocal(toFund);
 }

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,53 +1,45 @@
 'use strict';
 
-require('dotenv').config();
-const {
-    utils: { setJSON },
-    testnetInfo,
-} = require('@axelar-network/axelar-local-dev');
-const { Wallet, getDefaultProvider } = require('ethers');
+require("dotenv").config();
+const { utils: { setJSON}, testnetInfo } = require('@axelar-network/axelar-local-dev');
+const {  Wallet, getDefaultProvider } = require('ethers');
+const { keccak256, defaultAbiCoder } = require('ethers/lib/utils');
+const { GasCostLogger } = require('./gasCosts');
 
 async function deploy(env, chains, wallet, example) {
-    if (example.preDeploy) {
+    if(example.preDeploy) {
         await example.preDeploy(chains, wallet);
     }
-
     const promises = [];
-
-    for (const chain of chains) {
+    for(const chain of chains) {
         const rpc = chain.rpc;
         const provider = getDefaultProvider(rpc);
         promises.push(example.deploy(chain, wallet.connect(provider)));
     }
-
     await Promise.all(promises);
-
-    if (example.postDeploy) {
-        for (const chain of chains) {
+    if(example.postDeploy) {
+        for(const chain of chains) {
             const rpc = chain.rpc;
             const provider = getDefaultProvider(rpc);
             promises.push(example.postDeploy(chain, chains, wallet.connect(provider)));
         }
-
         await Promise.all(promises);
     }
-
     setJSON(chains, `./info/${env}.json`);
 }
 
 module.exports = {
     deploy,
-};
+}
+
 
 if (require.main === module) {
     const example = require(`../${process.argv[2]}/index.js`);
 
     const env = process.argv[3];
-    if (env == null || (env !== 'testnet' && env !== 'local'))
-        throw new Error('Need to specify testnet or local as an argument to this script.');
+    if(env == null || (env != 'testnet' && env != 'local')) throw new Error('Need to specify tesntet or local as an argument to this script.');
     let temp;
-
-    if (env === 'local') {
+    if(env == 'local') {
         temp = require(`../info/local.json`);
     } else {
         try {
@@ -56,11 +48,10 @@ if (require.main === module) {
             temp = testnetInfo;
         }
     }
-
     const chains = temp;
 
-    const privateKey = process.env.EVM_PRIVATE_KEY;
-    const wallet = new Wallet(privateKey);
+    const private_key = process.env.EVM_PRIVATE_KEY;
+    const wallet = new Wallet(private_key);
 
     deploy(env, chains, wallet, example);
 }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,41 +1,42 @@
 'use strict';
-require('dotenv').config();
+require("dotenv").config();
 
-const { testnetInfo } = require('@axelar-network/axelar-local-dev');
-const { Wallet } = require('ethers');
+const { utils: { setJSON }, testnetInfo } = require('@axelar-network/axelar-local-dev');
+const {  Wallet, getDefaultProvider, constants: { AddressZero } } = require('ethers');
+const { keccak256, defaultAbiCoder } = require('ethers/lib/utils');
+const { GasCostLogger } = require('./gasCosts');
 const { getGasPrice, getDepositAddress } = require('./utils.js');
+
+
 
 async function test(env, chains, args, wallet, example) {
     function wrappedGetGasPrice(source, destination, tokenAddress) {
         return getGasPrice(env, source, destination, tokenAddress);
     }
-
     function wrappedGetDepositAddress(source, destination, destinationAddress, symbol) {
         return getDepositAddress(env, source, destination, destinationAddress, symbol);
     }
-
+        
     await example.test(chains, wallet, {
-        getGasPrice: wrappedGetGasPrice,
+        getGasPrice: wrappedGetGasPrice, 
         getDepositAddress: wrappedGetDepositAddress,
-        args,
+        args: args
     });
 }
 
 module.exports = {
     test,
-};
+}
 
 if (require.main === module) {
-    const privateKey = process.env.EVM_PRIVATE_KEY;
-    const wallet = new Wallet(privateKey);
+    const private_key = process.env.EVM_PRIVATE_KEY;
+    const wallet = new Wallet(private_key);
 
     const example = require(`../${process.argv[2]}/index.js`);
     const env = process.argv[3];
-    if (env == null || (env !== 'testnet' && env !== 'local'))
-        throw new Error('Need to specify tesntet or local as an argument to this script.');
+    if(env == null || (env != 'testnet' && env != 'local')) throw new Error('Need to specify tesntet or local as an argument to this script.');
     let temp;
-
-    if (env === 'local') {
+    if(env == 'local') {
         temp = require(`../info/local.json`);
     } else {
         try {
@@ -44,7 +45,6 @@ if (require.main === module) {
             temp = testnetInfo;
         }
     }
-
     const chains = temp;
     const args = process.argv.slice(4);
 

--- a/test/local-examples.js
+++ b/test/local-examples.js
@@ -1,12 +1,15 @@
 'use strict';
 
-require('dotenv').config();
-const { Wallet } = require('ethers');
+require("dotenv").config();
+const {
+    utils: { defaultAbiCoder, keccak256 },
+    Wallet,
+} = require('ethers');
 const { createLocal } = require('../scripts/createLocal.js');
 const { test } = require('../scripts/test.js');
 const { deploy } = require('../scripts/deploy.js');
 const {
-    destroyExported,
+    stopAll,
     utils: { setLogger },
 } = require('@axelar-network/axelar-local-dev');
 const fs = require('fs-extra');
@@ -25,39 +28,26 @@ const examples = [
     'send-token',
 ];
 
-describe('Examples', function () {
-    // marked as slow if it takes longer than 15 seconds to run each test.
-    this.slow(15000);
-    this.timeout(20000);
-    // disable logging
+describe('examples', () => {
     setLogger((...args) => {});
-
-    console.log = () => {};
-
-    const deployerKey = process.env.EVM_PRIVATE_KEY;
-    const deployerAddress = new Wallet(deployerKey).address;
-    const toFund = [deployerAddress];
+    const deployer_key = process.env.EVM_PRIVATE_KEY;
+    const deployer_address = new Wallet(deployer_key).address;
+    const toFund = [deployer_address];
 
     beforeEach(async () => {
-        // Remove local.json before each test to ensure a clean start
-        if (fs.existsSync('./info/local.json')) {
-            fs.unlinkSync('./info/local.json');
-        }
-
         await createLocal(toFund);
     });
 
     afterEach(async () => {
-        await destroyExported();
+        await stopAll();
     });
 
     for (const exampleName of examples) {
-        it(exampleName, async function () {
-            const example = require(`../examples/${exampleName}/index.js`);
+        const example = require(`../examples/${exampleName}/index.js`);
+        it(exampleName, async () => {
             const chains = fs.readJsonSync('./info/local.json');
 
-            const wallet = new Wallet(deployerKey);
-
+            const wallet = new Wallet(deployer_key);
             if (example.deploy) await deploy('local', chains, wallet, example);
 
             await test('local', chains, [], wallet, example);


### PR DESCRIPTION
Reverts axelarnetwork/axelar-local-gmp-examples#52

We can't write contract objects into the chain object as it gets saved as JSON into `info/local.json`.

Running examples locally is broken right now
```
node scripts/deploy examples/call-contract local
node scripts/test examples/call-contract local "Moonbeam" "Avalanche" 'Hello World'
```
