### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/verify-cli-examples.yaml
+++ b/.github/workflows/verify-cli-examples.yaml
@@ -8,7 +8,7 @@ jobs:
         name: 'Test Cosmos Examples'
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node
               uses: actions/setup-node@v4
@@ -43,7 +43,7 @@ jobs:
         name: 'Test EVM Examples'
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node
               uses: actions/setup-node@v4
@@ -87,7 +87,7 @@ jobs:
                     - '9200:9200'
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node
               uses: actions/setup-node@v4

--- a/.github/workflows/verify-web-examples.yaml
+++ b/.github/workflows/verify-web-examples.yaml
@@ -16,7 +16,7 @@ jobs:
                   node-version: 18
 
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v5
 
             - name: Override config/ci.json
               run: |


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0